### PR TITLE
Added new UI for screenshots

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -465,13 +465,12 @@ h3 small {
   padding: 15px 15px 1px 15px;
   margin-top: 10px;
   margin-bottom: 20px;
-  margin-left: 25px;
 }
 
-.hidden-area.warning {
-  color: #8a6d3b;
-  background-color: #fcf8e3;
-  border: 1px solid #faebcc;
+.hidden-area.info {
+  color: #31708f;
+  background-color: #d9edf7;
+  border-color: #bce8f1;
 }
 
 .radio.radio-icon ~ .radio.radio-icon,

--- a/css/interface.css
+++ b/css/interface.css
@@ -450,3 +450,50 @@ h3 small {
 .app-build-status table td.app-build-download .fa {
   color: #b5b5b5;
 }
+
+.indented-area {
+  background-color: #f2f6f7;
+  border-radius: 6px;
+  padding: 15px 15px 1px 15px;
+  margin-top: 10px;
+}
+
+.hidden-area {
+  display: none;
+  background-color: #f2f6f7;
+  border-radius: 6px;
+  padding: 15px 15px 1px 15px;
+  margin-top: 10px;
+  margin-bottom: 20px;
+  margin-left: 25px;
+}
+
+.hidden-area.warning {
+  color: #8a6d3b;
+  background-color: #fcf8e3;
+  border: 1px solid #faebcc;
+}
+
+.radio.radio-icon ~ .radio.radio-icon,
+.checkbox.checkbox-icon ~ .checkbox.checkbox-icon {
+  margin-top: 5px;
+}
+
+.screenshot-previews {
+  margin-bottom: 20px;
+}
+
+.screenshot-previews.row {
+  margin-left: -5px;
+  margin-right: -5px;
+}
+
+.screenshot-previews .col-xs-3,
+.screenshot-previews .col-xs-12 {
+  padding-left: 5px;
+  padding-right: 5px;
+}
+
+.screenshot-previews img {
+  border: 1px solid #F0F0F0;
+}

--- a/css/interface.css
+++ b/css/interface.css
@@ -373,7 +373,7 @@ h3 small {
 
 .app-build-status table td.app-build-progress {
   text-align: right;
-  width: 100px;
+  width: 130px;
   vertical-align: top;
   padding: 10px 0;
 }

--- a/interface.html
+++ b/interface.html
@@ -460,6 +460,10 @@
           \{{#if ready-for-testing}}
           <td class="app-build-progress info">
             <div class="app-build-progress-holder"><i class="fa fa-bell"></i> Ready for testing</div>
+            \{{#if fileUrl}}
+            <div class="download-build"><a href="\{{fileUrl}}"><i class="fa fa-download"></i> Download file</a></div>\{{/if}}
+            \{{#if debugFileUrl}}
+            <div class="download-build"><a href="\{{debugFileUrl}}"><i class="fa fa-download"></i> Download debug app</a></div>\{{/if}}
           </td>
           <td class="app-build-details">
             \{{#if updatedAt}}<span><span class="icon"><i class="fa fa-clock-o"></i> Ready on:</span> \{{updatedAt}}</span>\{{/if}}

--- a/interface.html
+++ b/interface.html
@@ -483,7 +483,7 @@
           </td>
           <td class="app-build-details">
             \{{#if updatedAt}}<span><span class="icon"><i class="fa fa-clock-o"></i> Ready on:</span> \{{updatedAt}}</span>\{{/if}}
-            <div class="app-build-name">App is ready to be tested</div>
+            <div class="app-build-name">App ready for testing</div>
           </td>
           \{{/if}}
           \{{#if tested}}
@@ -492,7 +492,7 @@
           </td>
           <td class="app-build-details">
             \{{#if updatedAt}}<span><span class="icon"><i class="fa fa-clock-o"></i> Finished on:</span> \{{updatedAt}}</span>\{{/if}}
-            <div class="app-build-name">App was tested</div>
+            <div class="app-build-name">App tested</div>
           </td>
           \{{/if}}
           \{{#if failed}}

--- a/interface.html
+++ b/interface.html
@@ -82,8 +82,8 @@
                       <p><strong>We couldn't find any generated screenshots of your app!</strong><br>You won't need them at this stage, but when submitting the app to Google Play Store you will need to upload up to 4 screenshots of your app for mobile and tablet devices. Fliplet can help you generate the required screenshots, just go to <a href="#" onclick="Fliplet.Studio.emit('navigate', { name: 'launchAssets' })">App Settings</a>.</p>
                     </div>
                     <div data-item="fl-store-screenshots-new" class="hidden-area">
-                      <p>We will use the following screenshot in your app listing in the order shown below.<br>
-                      <small>We order the screenshots alphabetically, to reorder go to <a href="#" onclick="Fliplet.Studio.emit('navigate', { name: 'fileManager' })">File Manager</a> and rename your screenshots.</small></p>
+                      <p>We have found the following screenshots of your app:<br>
+                      <small>Go to <a href="#" onclick="Fliplet.Studio.emit('navigate', { name: 'fileManager' })">File Manager</a> to download these screenshots.</small></p>
 
                       <div class="row screenshot-previews">
                         <div class="col-xs-12"><strong>Mobile</strong></div>

--- a/interface.html
+++ b/interface.html
@@ -78,15 +78,8 @@
                     <label>App screenshots</label>
                   </div>
                   <div class="col-sm-8">
-                    <div class="radio radio-icon">
-                      <input type="radio" id="fl-store-screenshots-new" name="fl-store-screenshots" value="new">
-                      <label for="fl-store-screenshots-new">
-                        <span class="check"><i class="fa fa-circle"></i></span> Use new screenshots
-                      </label>
-                    </div>
-
-                    <div data-item="fl-store-screenshots-new-warning" class="hidden-area warning">
-                      <p>Apple requires you to upload up to 4 screenshots of your app for mobile and tablet devices. We could not find any screenshots in your folders, please go to <a href="#" onclick="Fliplet.Studio.emit('navigate', { name: 'launchAssets' })">App Settings</a> to generate your screenshots.</p>
+                    <div data-item="fl-store-screenshots-new-warning" class="hidden-area info">
+                      <p><strong>We couldn't find any generated screenshots of your app!</strong><br>You won't need them at this stage, but when submitting the app to Google Play Store you will need to upload up to 4 screenshots of your app for mobile and tablet devices. Fliplet can help you generate the required screenshots, just go to <a href="#" onclick="Fliplet.Studio.emit('navigate', { name: 'launchAssets' })">App Settings</a>.</p>
                     </div>
                     <div data-item="fl-store-screenshots-new" class="hidden-area">
                       <p>We will use the following screenshot in your app listing in the order shown below.<br>
@@ -103,19 +96,6 @@
 
                       <p>If you want to generate or upload new screenshots go to <a href="#" onclick="Fliplet.Studio.emit('navigate', { name: 'launchAssets' })">App Settings</a>.</p>
                     </div>
-
-                    <div class="radio radio-icon">
-                      <input type="radio" id="fl-store-screenshots-existing" name="fl-store-screenshots" value="existing">
-                      <label for="fl-store-screenshots-existing">
-                        <span class="check"><i class="fa fa-circle"></i></span> Use screenshots of existing app listing
-                      </label>
-                    </div>
-
-                    <div data-item="fl-store-screenshots-existing" class="hidden-area">
-                      <p>We will not upload new screenshots, we will use the existing screenshots on the app listing. By selecting this option you are confirming that you already have an app listing on the Apple App Store and that it contains the screenshots you want to be publicaly available.</p>
-                      <p class="text-warning">The app submission will fail if the app listing doesn’t contain screenshots.</p>
-                    </div>
-
                   </div>
                 </div>
                 <div class="form-group clearfix">

--- a/interface.html
+++ b/interface.html
@@ -75,13 +75,47 @@
                 </div>
                 <div class="form-group clearfix app-screenshots">
                   <div class="col-sm-4 control-label">
-                    <label>Screenshots</label>
-                    <p class="help-block label-helper"><small>Screenshots will be taken of the following screens</small></p>
-                    <p><a href="#" data-change-assets>Change</a></p>
+                    <label>App screenshots</label>
                   </div>
-                  <div class="col-sm-8 form-static">
-                    <input type="text" name="fl-store-screenshots" class="form-control-static" id="fl-store-screenshots" data-validate="true" disabled required/>
-                    <div class="help-block text-danger app-details-error">Click the change button to select the screens</div>
+                  <div class="col-sm-8">
+                    <div class="radio radio-icon">
+                      <input type="radio" id="fl-store-screenshots-new" name="fl-store-screenshots" value="new">
+                      <label for="fl-store-screenshots-new">
+                        <span class="check"><i class="fa fa-circle"></i></span> Use new screenshots
+                      </label>
+                    </div>
+
+                    <div data-item="fl-store-screenshots-new-warning" class="hidden-area warning">
+                      <p>Apple requires you to upload up to 4 screenshots of your app for mobile and tablet devices. We could not find any screenshots in your folders, please go to <a href="#" onclick="Fliplet.Studio.emit('navigate', { name: 'launchAssets' })">App Settings</a> to generate your screenshots.</p>
+                    </div>
+                    <div data-item="fl-store-screenshots-new" class="hidden-area">
+                      <p>We will use the following screenshot in your app listing in the order shown below.<br>
+                      <small>We order the screenshots alphabetically, to reorder go to <a href="#" onclick="Fliplet.Studio.emit('navigate', { name: 'fileManager' })">File Manager</a> and rename your screenshots.</small></p>
+
+                      <div class="row screenshot-previews">
+                        <div class="col-xs-12"><strong>Mobile</strong></div>
+                        <div class="mobile-thumbs"></div>
+                      </div>
+                      <div class="row screenshot-previews">
+                        <div class="col-xs-12"><strong>Tablet</strong></div>
+                        <div class="tablet-thumbs"></div>
+                      </div>
+
+                      <p>If you want to generate or upload new screenshots go to <a href="#" onclick="Fliplet.Studio.emit('navigate', { name: 'launchAssets' })">App Settings</a>.</p>
+                    </div>
+
+                    <div class="radio radio-icon">
+                      <input type="radio" id="fl-store-screenshots-existing" name="fl-store-screenshots" value="existing">
+                      <label for="fl-store-screenshots-existing">
+                        <span class="check"><i class="fa fa-circle"></i></span> Use screenshots of existing app listing
+                      </label>
+                    </div>
+
+                    <div data-item="fl-store-screenshots-existing" class="hidden-area">
+                      <p>We will not upload new screenshots, we will use the existing screenshots on the app listing. By selecting this option you are confirming that you already have an app listing on the Apple App Store and that it contains the screenshots you want to be publicaly available.</p>
+                      <p class="text-warning">The app submission will fail if the app listing doesn’t contain screenshots.</p>
+                    </div>
+
                   </div>
                 </div>
                 <div class="form-group clearfix">

--- a/interface.html
+++ b/interface.html
@@ -463,7 +463,8 @@
             \{{#if submittedAt}}<span><span class="icon"><i class="fa fa-clock-o"></i> Started on:</span> \{{submittedAt}}</span>\{{/if}}
             <div class="app-build-name">Building your app</div>
           </td>
-          \{{/if}} \{{#if completed}}
+          \{{/if}}
+          \{{#if completed}}
           <td class="app-build-progress success">
             <div class="app-build-progress-holder"><i class="fa fa-check-circle"></i> Completed</div>
             \{{#if fileUrl}}
@@ -475,7 +476,26 @@
             \{{#if updatedAt}}<span><span class="icon"><i class="fa fa-flag-checkered"></i> Finished on:</span> \{{updatedAt}}</span>\{{/if}}
             <div class="app-build-name">App successfully built</div>
           </td>
-          \{{/if}} \{{#if failed}}
+          \{{/if}}
+          \{{#if ready-for-testing}}
+          <td class="app-build-progress info">
+            <div class="app-build-progress-holder"><i class="fa fa-bell"></i> Ready for testing</div>
+          </td>
+          <td class="app-build-details">
+            \{{#if updatedAt}}<span><span class="icon"><i class="fa fa-clock-o"></i> Ready on:</span> \{{updatedAt}}</span>\{{/if}}
+            <div class="app-build-name">App is ready to be tested</div>
+          </td>
+          \{{/if}}
+          \{{#if tested}}
+          <td class="app-build-progress info">
+            <div class="app-build-progress-holder"><i class="fa fa-check-square-o"></i> Tested</div>
+          </td>
+          <td class="app-build-details">
+            \{{#if updatedAt}}<span><span class="icon"><i class="fa fa-clock-o"></i> Finished on:</span> \{{updatedAt}}</span>\{{/if}}
+            <div class="app-build-name">App was tested</div>
+          </td>
+          \{{/if}}
+          \{{#if failed}}
           <td class="app-build-progress danger">
             <div class="app-build-progress-holder"><i class="fa fa-exclamation-circle"></i> Failed</div>
             <div class="retry-build"><a href="#" data-retry-id="\{{id}}"><i class="fa fa-repeat"></i> Try again</a></div>

--- a/js/interface.js
+++ b/js/interface.js
@@ -138,12 +138,10 @@ function loadAppStoreData() {
     $('[name="' + name + '"]').val((typeof appStoreSubmission.data[name] !== "undefined") ? appStoreSubmission.data[name] : '');
   });
 
-  if (appIcon && ((hasFolders && screenShotsMobile.length && screenShotsTablet.length) || screenshotValidationNotRequired)) {
+  if (appIcon) {
     if (appSettings.splashScreen && appSettings.splashScreen.size && (appSettings.splashScreen.size[0] && appSettings.splashScreen.size[1]) < 2732) {
       $('.app-details-appStore .app-splash-screen').addClass('has-warning');
     }
-
-    $('.app-details-appStore .app-screenshots').removeClass('has-error');
 
     allAppData.push('appStore');
   } else {
@@ -155,13 +153,26 @@ function loadAppStoreData() {
     if (appSettings.splashScreen && appSettings.splashScreen.size && (appSettings.splashScreen.size[0] && appSettings.splashScreen.size[1]) < 2732) {
       $('.app-details-appStore .app-splash-screen').addClass('has-warning');
     }
-    if (hasFolders) {
-      if (screenShotsMobile.length == 0 || screenShotsTablet.length == 0) {
-        $('.app-details-appStore .app-screenshots').addClass('has-error');
-      }
-    } else {
-      $('.app-details-appStore .app-screenshots').addClass('has-error');
-    }
+  }
+
+  checkHasScreenshots();
+  if (!haveScreenshots) {
+    $('[data-item="fl-store-screenshots-new-warning"]').addClass('show');
+    $('[data-item="fl-store-screenshots-new"]').removeClass('show');
+    return;
+  }
+  if (haveScreenshots) {
+    $('[data-item="fl-store-screenshots-new-warning"]').removeClass('show');
+    $('[data-item="fl-store-screenshots-new"]').addClass('show');
+
+    _.take(screenShotsMobile, 4).forEach(function(thumb) {
+      $('.mobile-thumbs').append(addThumb(thumb));
+    });
+
+    _.take(screenShotsTablet, 4).forEach(function(thumb) {
+      $('.tablet-thumbs').append(addThumb(thumb));
+    });
+    return;
   }
 }
 
@@ -584,41 +595,6 @@ function checkGroupErrors() {
 }
 
 /* ATTACH LISTENERS */
-$('[name="fl-store-screenshots"]').on('change', function() {
-  var value = $(this).val();
-  var id = $(this).attr('id');
-  checkHasScreenshots();
-
-  if (value === 'new' && !haveScreenshots) {
-    $('[data-item="fl-store-screenshots-new-warning"]').addClass('show');
-
-    $('[data-item="fl-store-screenshots-new"]').removeClass('show');
-    $('[data-item="fl-store-screenshots-existing"]').removeClass('show');
-  }
-  if (value === 'new' && haveScreenshots) {
-    $('[data-item="fl-store-screenshots-new-warning"]').removeClass('show');
-    $('[data-item="fl-store-screenshots-new"]').addClass('show');
-
-    $('[data-item="fl-store-screenshots-existing"]').removeClass('show');
-
-    
-    _.take(screenShotsMobile, 4).forEach(function(thumb) {
-      $('.mobile-thumbs').append(addThumb(thumb));
-    });
-
-    _.take(screenShotsTablet, 4).forEach(function(thumb) {
-      $('.tablet-thumbs').append(addThumb(thumb));
-    });
-  }
-  if (value === 'existing') {
-    $('.app-details-appStore .app-screenshots').removeClass('has-error');
-    $('[data-item="fl-store-screenshots-existing"]').addClass('show');
-
-    $('[data-item="fl-store-screenshots-new-warning"]').removeClass('show');
-    $('[data-item="fl-store-screenshots-new"]').removeClass('show');
-  }
-});
-
 $('[name="submissionType"]').on('change', function() {
   var selectedOptionId = $(this).attr('id');
 

--- a/js/interface.js
+++ b/js/interface.js
@@ -830,7 +830,7 @@ function compileStatusTable(withData, origin, buildsData) {
 
 function checkSubmissionStatus(origin, googleSubmissions) {
   var submissionsToShow = _.filter(googleSubmissions, function(submission) {
-    return submission.status === "queued" || submission.status === "submitted" || submission.status === "processing" || submission.status === "completed" || submission.status === "failed" || submission.status === "cancelled";
+    return submission.status === "queued" || submission.status === "submitted" || submission.status === "processing" || submission.status === "completed" || submission.status === "failed" || submission.status === "cancelled" || submission.status === "ready-for-testing" || submission.status === "tested";
   });
 
   var buildsData = [];
@@ -861,7 +861,7 @@ function checkSubmissionStatus(origin, googleSubmissions) {
       }
 
       build.id = submission.id;
-      build.updatedAt = ((submission.status === 'completed' || submission.status === 'failed' || submission.status === "cancelled") && submission.updatedAt) ?
+      build.updatedAt = ((submission.status === 'completed' || submission.status === 'failed' || submission.status === 'cancelled' || submission.status === 'ready-for-testing' || submission.status === 'tested') && submission.updatedAt) ?
         moment(submission.updatedAt).format('MMM Do YYYY, h:mm:ss a') :
         '';
       build.submittedAt = ((submission.status === 'queued' || submission.status === 'submitted') && submission.submittedAt) ?

--- a/js/interface.js
+++ b/js/interface.js
@@ -142,9 +142,6 @@ function loadAppStoreData() {
     if (appSettings.splashScreen && appSettings.splashScreen.size && (appSettings.splashScreen.size[0] && appSettings.splashScreen.size[1]) < 2732) {
       $('.app-details-appStore .app-splash-screen').addClass('has-warning');
     }
-    // if (appSettings.iconData && appSettings.iconData.size && (appSettings.iconData.size[0] && appSettings.iconData.size[1]) < 1024) {
-    //   $('.app-details-appStore .app-icon-name').addClass('has-error');
-    // }
 
     $('.app-details-appStore .app-screenshots').removeClass('has-error');
 
@@ -226,9 +223,7 @@ function loadEnterpriseData() {
     if (appSettings.splashScreen && appSettings.splashScreen.size && (appSettings.splashScreen.size[0] && appSettings.splashScreen.size[1]) < 2732) {
       $('.app-details-ent .app-splash-screen').addClass('has-warning');
     }
-    // if (appSettings.iconData && appSettings.iconData.size && (appSettings.iconData.size[0] && appSettings.iconData.size[1]) < 1024) {
-    //   $('.app-details-ent .app-icon-name').addClass('has-error');
-    // }
+
     allAppData.push('enterprise');
   } else {
     $('.app-details-ent').addClass('required-fill');

--- a/js/interface.js
+++ b/js/interface.js
@@ -14,6 +14,11 @@ var $statusAppStoreTableElement = $('.app-build-appstore-status-holder');
 var $statusEnterpriseTableElement = $('.app-build-enterprise-status-holder');
 var initLoad;
 var userInfo;
+var hasFolders = false;
+var screenShotsMobile = [];
+var screenShotsTablet = [];
+var haveScreenshots = false;
+var screenshotValidationNotRequired = false;
 
 /* FUNCTIONS */
 String.prototype.toCamelCase = function() {
@@ -52,6 +57,15 @@ function incrementVersionCode(versionNumber) {
   return newVersionCode;
 }
 
+function checkHasScreenshots() {
+  haveScreenshots = hasFolders && screenShotsMobile.length && screenShotsTablet.length;
+}
+
+function addThumb(thumb) {
+  var template = Fliplet.Widget.Templates['templates.thumbs'];
+  return template(thumb);
+}
+
 function loadAppStoreData() {
 
   $('#appStoreConfiguration [name]').each(function(i, el) {
@@ -59,15 +73,12 @@ function loadAppStoreData() {
 
     /* APP SCREENSHOTS */
     if (name === "fl-store-screenshots") {
-      var screenNames = '';
-      if (appSettings.screensToScreenshot) {
-        appSettings.screensToScreenshot.forEach(function(screen) {
-          screenNames += screen.title + ", ";
-        });
-        screenNames = screenNames.replace(/\,[\s]$/g, '');
-        appStoreSubmission.data.appScreenshots = appSettings.screensToScreenshot;
+      if (appStoreSubmission.data[name]) {
+        $('[name="' + name + '"][value="' + appStoreSubmission.data[name] + '"]').prop('checked', true).trigger('change');
+        screenshotValidationNotRequired = appStoreSubmission.data[name] === 'existing'
+      } else {
+        $('[name="' + name + '"][value="new"]').prop('checked', true).trigger('change');
       }
-      $('[name="' + name + '"]').val(screenNames);
       return;
     }
 
@@ -127,13 +138,16 @@ function loadAppStoreData() {
     $('[name="' + name + '"]').val((typeof appStoreSubmission.data[name] !== "undefined") ? appStoreSubmission.data[name] : '');
   });
 
-  if (appIcon && (appSettings.screensToScreenshot && appSettings.screensToScreenshot.length)) {
+  if (appIcon && ((hasFolders && screenShotsMobile.length && screenShotsTablet.length) || screenshotValidationNotRequired)) {
     if (appSettings.splashScreen && appSettings.splashScreen.size && (appSettings.splashScreen.size[0] && appSettings.splashScreen.size[1]) < 2732) {
       $('.app-details-appStore .app-splash-screen').addClass('has-warning');
     }
     // if (appSettings.iconData && appSettings.iconData.size && (appSettings.iconData.size[0] && appSettings.iconData.size[1]) < 1024) {
     //   $('.app-details-appStore .app-icon-name').addClass('has-error');
     // }
+
+    $('.app-details-appStore .app-screenshots').removeClass('has-error');
+
     allAppData.push('appStore');
   } else {
     $('.app-details-appStore').addClass('required-fill');
@@ -144,7 +158,11 @@ function loadAppStoreData() {
     if (appSettings.splashScreen && appSettings.splashScreen.size && (appSettings.splashScreen.size[0] && appSettings.splashScreen.size[1]) < 2732) {
       $('.app-details-appStore .app-splash-screen').addClass('has-warning');
     }
-    if (!appSettings.screensToScreenshot || !appSettings.screensToScreenshot.length) {
+    if (hasFolders) {
+      if (screenShotsMobile.length == 0 || screenShotsTablet.length == 0) {
+        $('.app-details-appStore .app-screenshots').addClass('has-error');
+      }
+    } else {
       $('.app-details-appStore .app-screenshots').addClass('has-error');
     }
   }
@@ -346,7 +364,7 @@ function requestBuild(origin, submission) {
   $('.button-' + origin + '-request').html('Requesting <i class="fa fa-spinner fa-pulse fa-fw"></i>');
 
   if (origin === 'appStore') {
-    submission.data.screensToScreenshot = appSettings.screensToScreenshot;
+    submission.data.folderStructure = appSettings.folderStructure;
   }
 
   var defaultSplashScreenData = {
@@ -571,6 +589,41 @@ function checkGroupErrors() {
 }
 
 /* ATTACH LISTENERS */
+$('[name="fl-store-screenshots"]').on('change', function() {
+  var value = $(this).val();
+  var id = $(this).attr('id');
+  checkHasScreenshots();
+
+  if (value === 'new' && !haveScreenshots) {
+    $('[data-item="fl-store-screenshots-new-warning"]').addClass('show');
+
+    $('[data-item="fl-store-screenshots-new"]').removeClass('show');
+    $('[data-item="fl-store-screenshots-existing"]').removeClass('show');
+  }
+  if (value === 'new' && haveScreenshots) {
+    $('[data-item="fl-store-screenshots-new-warning"]').removeClass('show');
+    $('[data-item="fl-store-screenshots-new"]').addClass('show');
+
+    $('[data-item="fl-store-screenshots-existing"]').removeClass('show');
+
+    
+    _.take(screenShotsMobile, 4).forEach(function(thumb) {
+      $('.mobile-thumbs').append(addThumb(thumb));
+    });
+
+    _.take(screenShotsTablet, 4).forEach(function(thumb) {
+      $('.tablet-thumbs').append(addThumb(thumb));
+    });
+  }
+  if (value === 'existing') {
+    $('.app-details-appStore .app-screenshots').removeClass('has-error');
+    $('[data-item="fl-store-screenshots-existing"]').addClass('show');
+
+    $('[data-item="fl-store-screenshots-new-warning"]').removeClass('show');
+    $('[data-item="fl-store-screenshots-new"]').removeClass('show');
+  }
+});
+
 $('[name="submissionType"]').on('change', function() {
   var selectedOptionId = $(this).attr('id');
 
@@ -970,11 +1023,47 @@ function initialLoad(initial, timeout) {
         ]);
       })
       .then(function() {
+        if (appSettings.folderStructure) {
+          var structure = [];
+          hasFolders = true;
+          var appleOnly = _.filter(appSettings.folderStructure, function(obj) {
+            return obj.platform === 'apple';
+          });
+
+          return Promise.all(appleOnly.map((obj) => {
+            return Fliplet.Media.Folders.get({folderId: obj.folderId})
+              .then(function(result) {
+                var tempObject = {
+                  type: obj.type,
+                  folderContent: result
+                }
+
+                structure.push(tempObject);
+                return Promise.resolve(structure);
+              });
+          }))
+          .then(function() {
+            structure.forEach(function(el, idx) {
+              if (el.type === 'mobile') {
+                screenShotsMobile = el.folderContent.files
+              }
+              if (el.type === 'tablet') {
+                screenShotsTablet = el.folderContent.files
+              }
+            });
+          });
+        } else {
+          hasFolders = false;
+          return;
+        }
+      })
+      .then(function() {
         return Fliplet.API.request({
           method: 'GET',
           url: 'v1/widget-instances/com.fliplet.push-notifications?appId=' + Fliplet.Env.get('appId')
         });
-      }).then(function(response) {
+      })
+      .then(function(response) {
         if (response.widgetInstance.settings && response.widgetInstance.settings) {
           notificationSettings = response.widgetInstance.settings;
         } else {

--- a/js/interface.templates.js
+++ b/js/interface.templates.js
@@ -1,0 +1,11 @@
+this["Fliplet"] = this["Fliplet"] || {};
+this["Fliplet"]["Widget"] = this["Fliplet"]["Widget"] || {};
+this["Fliplet"]["Widget"]["Templates"] = this["Fliplet"]["Widget"]["Templates"] || {};
+
+this["Fliplet"]["Widget"]["Templates"]["templates.thumbs"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
+    var helper;
+
+  return "<div class=\"col-xs-3\">\n  <img src=\""
+    + container.escapeExpression(((helper = (helper = helpers.url || (depth0 != null ? depth0.url : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"url","hash":{},"data":data}) : helper)))
+    + "\"/>\n</div>";
+},"useData":true});

--- a/js/templates/thumbs.interface.hbs
+++ b/js/templates/thumbs.interface.hbs
@@ -1,0 +1,3 @@
+<div class="col-xs-3">
+  <img src="{{url}}"/>
+</div>

--- a/widget.json
+++ b/widget.json
@@ -19,6 +19,7 @@
       "moment"
     ],
     "assets": [
+      "js/interface.templates.js",
       "img/app-icon.png",
       "img/splash-screen.png",
       "vendor/bootstrap-tokenfield.css",


### PR DESCRIPTION
## How to integrate with your script

- You need to look for the key `fl-store-screenshots` and if the value is `new` then:
  - You look in the app settings for the property `folderStructure` or you can find it in `submission.data.folderStructure`.
    This is an array of objects:
    ```js
    [
      {
        folderId: 123,
        platform: 'apple',
        type: 'mobile',
        width: 414,
        height: 736,
        zoom: 3
      },
      {
        folderId: 123,
        platform: 'apple',
        type: 'tablet',
        width: 1024,
        height: 1366,
        zoom: 2
      },
      {
        folderId: 123,
        platform: 'google',
        type: 'mobile',
        width: 360,
        height: 640,
        zoom: 2
      },
      {
        folderId: 123,
        platform: 'google',
        type: 'tablet',
        width: 600,
        height: 1024,
        zoom: 2
      }
    ]
    ```
    On this array you will have the object that contains the folder ID for the Apple tablet and the Apple mobile screenshots.
    You can get the files for apple like this:
    ```js
    var structure = [];
    // Filters only Apple folders
    var appleOnly = _.filter(appSettings.folderStructure, function(obj) {
      return obj.platform === 'apple';
    });

    return Promise.all(appleOnly.map((obj) => {
      return Fliplet.Media.Folders.get({folderId: obj.folderId})
        .then(function(result) {
          var tempObject = {
            type: obj.type,
            folderContent: result
          }
          structure.push(tempObject);
          return Promise.resolve(structure);
        });
    }))
    .then(function() {
      structure.forEach(function(el, idx) {
        if (el.type === 'mobile') {
          // Saves only mobile screenshots in array
          var screenShotsMobile = el.folderContent.files
        }
        if (el.type === 'tablet') {
          // Saves only tablet screenshots in array
          var screenShotsTablet = el.folderContent.files
        }
      });
    });
    ```
    You will need to limit the returned array of files (`screenShotsMobile` and `screenShotsTablet`) to 4 with `_.take(arrayHere, 4)`.
- If the value of `fl-store-screenshots` is `existing` it means that the user wants to used the screenshots that already exist on the app listing.

## Screenshot of UI
<img width="658" alt="screen shot 2017-12-13 at 18 35 56" src="https://user-images.githubusercontent.com/7046481/33955738-7d7c2f74-e034-11e7-9a46-27ab9ae8a302.png">


