### PR TITLE
When app is successfully requested, Modal window opens and page scrolls to 'building app' section

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -234,8 +234,6 @@ h3 small {
 
 .save-enterprise-progress,
 .save-unsigned-progress,
-.save-enterprise-request,
-.save-unsigned-request,
 .save-push-progress {
   opacity: 0;
   -webkit-transition: opacity 0.25s ease;
@@ -244,22 +242,14 @@ h3 small {
 
 .save-enterprise-progress.saved,
 .save-unsigned-progress.saved,
-.save-enterprise-request.saved,
-.save-unsigned-request.saved,
 .save-push-progress.saved {
   opacity: 1;
 }
 
 .save-appStore-progress,
-.save-appStore-request {
+.save-appStore-progress.saved {
   display: none;
 }
-
-.save-appStore-progress.saved,
-.save-appStore-request.saved {
-  display: none;
-}
-
 
 /* App Settings Replica */
 

--- a/interface.html
+++ b/interface.html
@@ -1,5 +1,5 @@
 <div class="form-horizontal">
-  <ul class="nav nav-tabs" role="tablist">
+  <ul class="nav nav-tabs" role="tablist" id="nav-tabs">
     <li role="presentation" class="active" id="appstore-control">
       <a href="#appstore-tab" aria-controls="appstore" role="tab" data-toggle="tab">
         <span>Google Play</span>
@@ -193,7 +193,6 @@
           <div class="col-xs-5 save-btn-holder col-xs-offset-2 text-right">
             <p class="help-block"><small>Submit your information when you are ready!<br>We will take care of the rest.</small></p>
             <button type="submit" class="btn btn-primary fl-green button-appStore-request" data-app-store-build>Request App <i class="fa fa-paper-plane"></i></button>
-            <p class="text-success save-appStore-request">Your request was sent successfully!</p>
           </div>
         </div>
       </form>
@@ -387,7 +386,6 @@
         <div class="col-xs-5 save-btn-holder col-xs-offset-2 text-right">
           <p class="help-block"><small>Submit your information when you are ready!<br>We will take care of the rest.</small></p>
           <button type="submit" class="btn btn-primary fl-green button-enterprise-request" data-enterprise-build>Request App <i class="fa fa-paper-plane"></i></button>
-          <p class="text-success save-enterprise-request">Your request was sent successfully!</p>
         </div>
       </form>
     </div>

--- a/js/interface.js
+++ b/js/interface.js
@@ -342,7 +342,7 @@ function submissionBuild(appSubmission, origin) {
         title: 'Your request was sent successfully!',
         message: 'Your app is building!'
       }).then(function () {
-        document.getElementById('nav-tabs').scrollIntoView({behavior: "smooth", block: "start"});
+        document.getElementById('nav-tabs').scrollIntoView({ behavior: 'smooth', block: 'start' });
       });
 
     $('.button-' + origin + '-request').html('Request App <i class="fa fa-paper-plane"></i>');

--- a/js/interface.js
+++ b/js/interface.js
@@ -338,21 +338,20 @@ function submissionBuild(appSubmission, origin) {
 
     Fliplet.Studio.emit('refresh-app-submissions');
 
+    Fliplet.Modal.alert({
+        title: 'Your request was sent successfully!',
+        message: 'Your app is building!'
+      }).then(function () {
+        document.getElementById('nav-tabs').scrollIntoView({behavior: "smooth", block: "start"});
+      });
+
     $('.button-' + origin + '-request').html('Request App <i class="fa fa-paper-plane"></i>');
     $('.button-' + origin + '-request').prop('disabled', false);
-    $('.save-' + origin + '-request').addClass('saved').hide().fadeIn(250);
 
     clearTimeout(initLoad);
     initialLoad(false, 0);
 
     Fliplet.Widget.autosize();
-
-    setTimeout(function() {
-      $('.save-' + origin + '-request').fadeOut(250, function() {
-        $('.save-' + origin + '-request').removeClass('saved');
-        Fliplet.Widget.autosize();
-      });
-    }, 10000);
   }, function(err) {
     $('.button-' + origin + '-request').html('Request App <i class="fa fa-paper-plane"></i>');
     $('.button-' + origin + '-request').prop('disabled', false);
@@ -640,7 +639,7 @@ function saveProgressOnClose () {
     "appstore-control": saveAppStoreData,
     "fliplet-signed-control": saveEnterpriseData
   }
-  
+
   //Finding out active tab to use correct save method
   var activeTabId = $(".nav.nav-tabs li.active").prop("id");
 
@@ -771,7 +770,7 @@ $('.redirectToSettings, [data-change-settings]').on('click', function(event) {
     Fliplet.Studio.emit('close-overlay', {
       name: 'publish-google'
     });
-  
+
     Fliplet.Studio.emit('overlay', {
       name: 'app-settings',
       options: {
@@ -796,7 +795,7 @@ $('[data-change-assets]').on('click', function(event) {
     Fliplet.Studio.emit('close-overlay', {
       name: 'publish-google'
     });
-  
+
     Fliplet.Studio.emit('overlay', {
       name: 'app-settings',
       options: {
@@ -1275,12 +1274,12 @@ function initialLoad(initial, timeout) {
           })
           .then(function(res) {
             var isEnabled = !_.isEmpty(res.widgets[0].instances);
-            
+
             if (isEnabled) {
               $('[data-fl-analytics-status]').each(function(index, item) {
                 $(item).html('Enabled').addClass('analytic-enabled');
-              }) 
-            } 
+              })
+            }
           })
         ]);
       })


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#2832

## Description
Now when app is successfully requested, Modal window is fired. After confirming it, the page gets scrolled to 'building app' section. 
Removed green text 'Your request was sent successfully!' under Request App button and all CSS related to it.

## Screenshots/screencasts
Edge 
![edge go up fix](https://user-images.githubusercontent.com/52824207/64959815-a2d5e200-d89a-11e9-85d0-c36838c92791.gif)

Chrome
![Apple demo](https://user-images.githubusercontent.com/52824207/64960033-1972df80-d89b-11e9-9e34-97e6faea7f24.gif)

## Backward compatibility
This change is fully backward compatible.

## Notes
Behavior: "smooth" attribute that gives smooth scrolling works only on Chrome, Firefox, Opera. Other browsers (IE, Edge) will scroll page instantly. 