### PR TITLE
Removed "Try again" to rebuild app method

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -379,7 +379,6 @@ h3 small {
   padding: 10px 0;
 }
 
-.app-build-status table td.app-build-progress .retry-build,
 .app-build-status table td.app-build-progress .download-build,
 .app-build-status table td.app-build-progress .cancel-build {
   font-size: 12px;

--- a/interface.html
+++ b/interface.html
@@ -523,7 +523,6 @@
           \{{#if failed}}
           <td class="app-build-progress danger">
             <div class="app-build-progress-holder"><i class="fa fa-exclamation-circle"></i> Failed</div>
-            <div class="retry-build"><a href="#" data-retry-id="\{{id}}"><i class="fa fa-repeat"></i> Try again</a></div>
           </td>
           <td class="app-build-details">
             \{{#if updatedAt}}<span><span class="icon"><i class="fa fa-flag-checkered"></i> Finished on:</span> \{{updatedAt}}</span>\{{/if}}


### PR DESCRIPTION
@tonytlwu @squallstar

## Issue
Fliplet/fliplet-studio#4321

## Description
Removed "Try again" from HTML, removed unused CSS style.

## Screenshots/screencasts
Look without "Try again"

<img width="854" alt="Android look" src="https://user-images.githubusercontent.com/52824207/65037945-7b911a80-d957-11e9-8e2f-daa43b38e7d7.png">

## Backward compatibility
This change is fully backward compatible.