### PR TITLE
Bundle ID name will be hidden if it is too long, tooltip will appear to display full name

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -107,15 +107,15 @@
   margin: 0;
 }
 
-.bundleId-ast-text,
-.bundleId-ent-text {
+.bundleId-store-text,
+.bundleId-apk-text {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.bundleId-ast-text:before,
-.bundleId-ent-text:before {
+.bundleId-store-text:before,
+.bundleId-apk-text:before {
   content: '';
   display: block;
 }

--- a/css/interface.css
+++ b/css/interface.css
@@ -107,6 +107,19 @@
   margin: 0;
 }
 
+.bundleId-ast-text,
+.bundleId-ent-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bundleId-ast-text:before,
+.bundleId-ent-text:before {
+  content: '';
+  display: block;
+}
+
 .nav-tabs>li>a span {
   display: block;
   text-align: center;
@@ -489,4 +502,9 @@ h3 small {
 
 .analytic-enabled {
   color: #6aa84f;
+}
+
+.tooltip-inner {
+  max-width: 320px;
+  word-wrap: break-word;
 }

--- a/interface.html
+++ b/interface.html
@@ -122,12 +122,12 @@
                     <p class="help-block label-helper"><small>This is a unique ID for your app on Google Play. Fliplet auto-generated one for you. <strong>The Bundle ID will appear in the Google Play listing link.</strong></small></p>
                   </div>
                   <div class="col-sm-8 fl-bundleId-holder">
-                    <span class="bundleId-ast-text"></span> <span class="btn btn-sm btn-default" change-bundleid>Change</span>
+                    <span class="bundleId-ast-text" data-toggle="tooltip" data-placement="bottom" title=""></span> <span class="btn btn-sm btn-default" change-bundleid>Change</span>
                     <div class="help-block with-errors"></div>
                   </div>
                   <div class="fl-bundleId-field">
                     <div class="col-sm-8">
-                      <input type="text" name="fl-store-bundleId" class="form-control" id="fl-store-bundleId" data-error="Please enter the Bundle ID" required />
+                      <input type="text" name="fl-store-bundleId" class="form-control" id="fl-store-bundleId" data-error="Please enter the Bundle ID" maxlength="155" required />
                       <div class="help-block with-errors"></div>
                       <p class="help-block"><small>This value needs to be unique and the structure must be <code>com.<i>organizationName</i>.<i>appName</i></code>.</small></p>
                     </div>
@@ -351,12 +351,12 @@
                     <p class="help-block label-helper"><small>This is a unique ID for your app on Google Play. Fliplet auto-generated one for you.</small></p>
                   </div>
                   <div class="col-sm-8 fl-bundleId-holder">
-                    <span class="bundleId-ent-text"></span> <span class="btn btn-sm btn-default" change-bundleid>Change</span>
+                    <span class="bundleId-ent-text" data-toggle="tooltip" data-placement="bottom" title=""></span> <span class="btn btn-sm btn-default" change-bundleid>Change</span>
                     <div class="help-block with-errors"></div>
                   </div>
                   <div class="fl-bundleId-field">
                     <div class="col-sm-8">
-                      <input type="text" name="fl-ent-bundleId" class="form-control" id="fl-ent-bundleId" data-error="Please enter your Bundle ID" required />
+                      <input type="text" name="fl-ent-bundleId" class="form-control" id="fl-ent-bundleId" data-error="Please enter your Bundle ID" maxlength="155" required />
                       <div class="help-block with-errors"></div>
                       <p class="help-block"><small>This value needs to be unique and the structure must be <code>com.<i>organizationName</i>.<i>appName</i></code>.</small></p>
                     </div>

--- a/interface.html
+++ b/interface.html
@@ -122,7 +122,7 @@
                     <p class="help-block label-helper"><small>This is a unique ID for your app on Google Play. Fliplet auto-generated one for you. <strong>The Bundle ID will appear in the Google Play listing link.</strong></small></p>
                   </div>
                   <div class="col-sm-8 fl-bundleId-holder">
-                    <span class="bundleId-ast-text" data-toggle="tooltip" data-placement="bottom" title=""></span> <span class="btn btn-sm btn-default" change-bundleid>Change</span>
+                    <span class="bundleId-store-text" data-toggle="tooltip" data-placement="bottom" title=""></span> <span class="btn btn-sm btn-default" change-bundleid>Change</span>
                     <div class="help-block with-errors"></div>
                   </div>
                   <div class="fl-bundleId-field">
@@ -351,7 +351,7 @@
                     <p class="help-block label-helper"><small>This is a unique ID for your app on Google Play. Fliplet auto-generated one for you.</small></p>
                   </div>
                   <div class="col-sm-8 fl-bundleId-holder">
-                    <span class="bundleId-ent-text" data-toggle="tooltip" data-placement="bottom" title=""></span> <span class="btn btn-sm btn-default" change-bundleid>Change</span>
+                    <span class="bundleId-apk-text" data-toggle="tooltip" data-placement="bottom" title=""></span> <span class="btn btn-sm btn-default" change-bundleid>Change</span>
                     <div class="help-block with-errors"></div>
                   </div>
                   <div class="fl-bundleId-field">

--- a/js/interface.js
+++ b/js/interface.js
@@ -144,17 +144,17 @@ function loadAppStoreData() {
     if (name === "fl-store-bundleId" && typeof appStoreSubmission.data[name] === "undefined") {
       createBundleID(organizationName.toCamelCase(), appName.toCamelCase()).then(function(response) {
         if (response.resultCount === 0) {
-          $('.bundleId-ast-text').html('com.' + organizationName.toCamelCase() + '.' + appName.toCamelCase());
+          $('.bundleId-store-text').html('com.' + organizationName.toCamelCase() + '.' + appName.toCamelCase());
           $('[name="' + name + '"]').val('com.' + organizationName.toCamelCase() + '.' + appName.toCamelCase());
         } else {
-          $('.bundleId-ast-text').html('com.' + organizationName.toCamelCase() + '.' + appName.toCamelCase() + (response.resultCount + 1));
+          $('.bundleId-store-text').html('com.' + organizationName.toCamelCase() + '.' + appName.toCamelCase() + (response.resultCount + 1));
           $('[name="' + name + '"]').val('com.' + organizationName.toCamelCase() + '.' + appName.toCamelCase() + (response.resultCount + 1));
         }
       });
       return;
     }
     if (name === "fl-store-bundleId" && typeof appStoreSubmission.data[name] !== "undefined") {
-      $('.bundleId-ast-text').html(appStoreSubmission.data[name]);
+      $('.bundleId-store-text').html(appStoreSubmission.data[name]);
       $('[name="' + name + '"]').val(appStoreSubmission.data[name]);
       return;
     }
@@ -229,17 +229,17 @@ function loadEnterpriseData() {
     if (name === "fl-ent-bundleId" && typeof enterpriseSubmission.data[name] === "undefined") {
       createBundleID(organizationName.toCamelCase(), appName.toCamelCase()).then(function(response) {
         if (response.resultCount === 0) {
-          $('.bundleId-ent-text').html('com.' + organizationName.toCamelCase() + '.' + appName.toCamelCase());
+          $('.bundleId-apk-text').html('com.' + organizationName.toCamelCase() + '.' + appName.toCamelCase());
           $('[name="' + name + '"]').val('com.' + organizationName.toCamelCase() + '.' + appName.toCamelCase());
         } else {
-          $('.bundleId-ent-text').html('com.' + organizationName.toCamelCase() + '.' + appName.toCamelCase() + (response.resultCount + 1));
+          $('.bundleId-apk-text').html('com.' + organizationName.toCamelCase() + '.' + appName.toCamelCase() + (response.resultCount + 1));
           $('[name="' + name + '"]').val('com.' + organizationName.toCamelCase() + '.' + appName.toCamelCase() + (response.resultCount + 1));
         }
       });
       return;
     }
     if (name === "fl-ent-bundleId" && typeof enterpriseSubmission.data[name] !== "undefined") {
-      $('.bundleId-ent-text').html(enterpriseSubmission.data[name]);
+      $('.bundleId-apk-text').html(enterpriseSubmission.data[name]);
       $('[name="' + name + '"]').val(enterpriseSubmission.data[name]);
       return;
     }
@@ -700,7 +700,7 @@ $('[data-toggle="tooltip"]').tooltip({
     }
     return tooltipText;
   },
-  delay: { "show": 500, "hide": 300 }
+  delay: { show: 500, hide: 300 }
 });
 
 $('[name="submissionType"]').on('change', function() {

--- a/js/interface.js
+++ b/js/interface.js
@@ -691,6 +691,18 @@ function checkGroupErrors() {
 }
 
 /* ATTACH LISTENERS */
+
+$('[data-toggle="tooltip"]').tooltip({
+  title: function() {
+    var tooltipText = $(this).text();
+    if (tooltipText.length < 41) {
+      return;
+    }
+    return tooltipText;
+  },
+  delay: { "show": 500, "hide": 300 }
+});
+
 $('[name="submissionType"]').on('change', function() {
   var selectedOptionId = $(this).attr('id');
 


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#4668

## Description
Limited max length on the bundle ID input to 155 chars. Added bootstrap tooltip. Bundle ID name will be hidden if it is too long.

## Screenshots/screencasts
![bundleid demo ](https://user-images.githubusercontent.com/52824207/65590801-0dbaa380-df94-11e9-8bad-7c7bc6a823d3.gif)

## Backward compatibility
This change is fully backward compatible.