### PR TITLE
The "Building your app" info tab will appear right away on production

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -1056,7 +1056,7 @@ function checkSubmissionStatus(origin, googleSubmissions) {
 
       // Default copy for testing status for different users
       if (submission.status === 'ready-for-testing') {
-        if (userInfo.user && (userInfo.user.isAdmin || userInfo.user.isImpersonating)) {
+        if (userInfo && userInfo.user && (userInfo.user.isAdmin || userInfo.user.isImpersonating)) {
           // Fliplet users
           build.testingStatus = 'Ready for testing';
           build.testingMessage = 'App is ready for testing';
@@ -1097,7 +1097,7 @@ function checkSubmissionStatus(origin, googleSubmissions) {
       build[submission.status] = true;
       build.fileUrl = appBuild ? appBuild.url : '';
 
-      if (userInfo.user && (userInfo.user.isAdmin || userInfo.user.isImpersonating)) {
+      if (userInfo && userInfo.user && (userInfo.user.isAdmin || userInfo.user.isImpersonating)) {
         build.debugFileUrl = debugApp ? debugApp.url : '';
       }
 


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#4085

## Description
The bug occurred because on the first load when userInfo is not yet received it was trying to find userInfo.user of undefined. I copied this fix from the Apple aab component.

## Screenshots/screencasts
![Android demo](https://user-images.githubusercontent.com/52824207/66843167-1429b300-ef75-11e9-8c04-5da02621b10b.gif)

## Backward compatibility
This change is fully backward compatible.

## Notes
(Note any breaking changes, documentation for new features or actions to take after deployment etc.)