### PR TITLE
Emit accordion scroll event to Studio

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -981,7 +981,7 @@ $('.panel-collapse').on('shown.bs.collapse', function () {
     return;
   }
 
-  Fliplet.Studio.emit('accordionScroll', $panel.offset().top);
+  Fliplet.Studio.emit('scrollTo', $panel.offset().top);
 });
 
 $(document).on('click', '[data-cancel-build-id]', function() {

--- a/js/interface.js
+++ b/js/interface.js
@@ -728,7 +728,7 @@ $('[name="submissionType"]').on('change', function() {
 
 $('#fl-store-firebase').on('change', function() {
   var fileName = this.value.replace(/\\/g, '/').replace(/.*\//, '');
-  var fileExtension = checkFileExtension(fileName, this); 
+  var fileExtension = checkFileExtension(fileName, this);
 
   if (!fileExtension) {
     return;
@@ -744,7 +744,7 @@ $('#fl-store-firebase').on('change', function() {
 
 $("#fl-ent-firebase").on('change', function() {
   var fileName = this.value.replace(/\\/g, '/').replace(/.*\//, '');
-  var fileExtension = checkFileExtension(fileName, this); 
+  var fileExtension = checkFileExtension(fileName, this);
 
   if (!fileExtension) {
     return;
@@ -971,6 +971,17 @@ $('[data-enterprise-save]').on('click', function() {
 });
 $('[data-push-save]').on('click', function() {
   savePushData();
+});
+
+// Scroll accordion tab to the top
+$('.panel-collapse').on('shown.bs.collapse', function () {
+  var $panel = $(this).closest('.panel');
+
+  if (!$panel || !$panel.offset()) {
+    return;
+  }
+
+  Fliplet.Studio.emit('accordionScroll', $panel.offset().top);
 });
 
 $(document).on('click', '[data-cancel-build-id]', function() {


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/2149

## Description
When changing an accordion offset value is emitted to the studio. Added some error prevention.

## Backward compatibility
This change is fully backward compatible.

## Notes
To make this work studio Studio should be updated to use received offset top value to scroll the page. 
Sample usage:
 $('html,body').animate({
    scrollTop: value
  }, 500); 