### PR TITLE
Scrolling to the top of the tab

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -981,7 +981,7 @@ $('.panel-collapse').on('shown.bs.collapse', function () {
     return;
   }
 
-  Fliplet.Studio.emit('scrollTo', $panel.offset().top);
+  Fliplet.Studio.emit('scrollElementTo', $panel.offset().top);
 });
 
 $(document).on('click', '[data-cancel-build-id]', function() {


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/2149

## Description
Changed event name

## Screenshots/screencasts
![GoogleSubGoUp](https://user-images.githubusercontent.com/53430352/72802362-49206280-3c54-11ea-8e67-543be01691ba.gif)

## Backward compatibility

This change is fully backward compatible.

## Notes
We decide to use this even name because when this event will fire we shall scroll an element to the needed position and not only in the element we will use it in the apple AAB as well.
