### PR TITLE
Changed event name that it matches with the event name in the studio

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -981,7 +981,7 @@ $('.panel-collapse').on('shown.bs.collapse', function () {
     return;
   }
 
-  Fliplet.Studio.emit('scrollElementTo', $panel.offset().top);
+  Fliplet.Studio.emit('scrollOverlayTo', $panel.offset().top);
 });
 
 $(document).on('click', '[data-cancel-build-id]', function() {


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/2149

## Description
Changed event name that it matches with the event name in the studio

## Backward compatibility

This change is fully backward compatible.

## Notes
Works with this [PR](https://github.com/Fliplet/fliplet-studio/pull/5614)