### PR TITLE
OD-355 [Fix] App settings link for screenshots redirects to `Launch assets`

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -75,7 +75,7 @@
                   </div>
                   <div class="col-sm-8">
                     <div data-item="fl-store-screenshots-new-warning" class="hidden-area info">
-                      <p><strong>We couldn't find any generated screenshots of your app!</strong><br>You won't need them at this stage, but when submitting the app to Google Play Store you will need to upload up to 4 screenshots of your app for mobile and tablet devices. Fliplet can help you generate the required screenshots, just go to <a href="#" onclick="Fliplet.Studio.emit('navigate', { name: 'launchAssets' })">App Settings</a>.</p>
+                      <p><strong>We couldn't find any generated screenshots of your app!</strong><br>You won't need them at this stage, but when submitting the app to Google Play Store you will need to upload up to 4 screenshots of your app for mobile and tablet devices. Fliplet can help you generate the required screenshots, just go to <a href="#" data-change-assets>App Settings</a>.</p>
                     </div>
                     <div data-item="fl-store-screenshots-new" class="hidden-area">
                       <p>We will use the following screenshot in your app listing in the order shown below.<br>


### PR DESCRIPTION
@sofiiakvasnevska
## Issue
OD-355 https://weboo.atlassian.net/browse/OD-355
## Description
App settings link for screenshots redirects to `Launch assets`
## Screenshots/screencasts
https://monosnap.com/file/0iOtOBxmfvjAGziNcBacmDfUemM0OX
## Backward compatibility
This change is fully backward compatible.
## Reviewers 
@upplabs-alex-levchenko @YaroslavOvdii