### PR TITLE
ID-1292 [Feat] New content type for app build file

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -1105,7 +1105,7 @@ function compileStatusTable(withData, origin, buildsData) {
 }
 
 function fileIsAPK(file) {
-  return file.contentType === 'application/vnd.android.package-archive';
+  return file.contentType === 'application/x-authorware-bin' || file.contentType === 'application/vnd.android.package-archive';
 }
 
 function checkSubmissionStatus(origin, googleSubmissions) {


### PR DESCRIPTION
This patch allows the UI to display an *.aab file when available.