### PR TITLE
ID-2119 [Fix] Improve version code validation to correctly check for numbers

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -349,7 +349,7 @@
                     <p class="help-block label-helper"><small>This is the version code of your app.</small></p>
                   </div>
                   <div class="col-sm-8">
-                    <input type="text" name="fl-ent-versionCode" class="form-control" id="fl-ent-versionCode" pattern="^\d{1,4}$" data-error="The version code must be a number without any decimals and higher than all existing version codes" data-validation-version-code data-validation-version-code-error data-required-error="Please enter an app version code" data-validation-version-code-type data-validation-version-code-type-error="Please make sure the version code is higher than 1000" required />
+                    <input type="text" name="fl-ent-versionCode" class="form-control" id="fl-ent-versionCode" pattern="^\d+$" data-error="The version code must be a number without any decimals and higher than all existing version codes" data-validation-version-code data-validation-version-code-error data-required-error="Please enter an app version code" data-validation-version-code-type data-validation-version-code-type-error="Please make sure the version code is higher than 1000" required />
                     <div class="help-block with-errors"></div>
                     <p class="help-block"><small>The version code must be a number without any decimals and higher than all existing version codes.</small></p>
                   </div>

--- a/interface.html
+++ b/interface.html
@@ -113,7 +113,7 @@
                     <p class="help-block label-helper"><small>This is the version code of your app.</small></p>
                   </div>
                   <div class="col-sm-8">
-                    <input type="text" name="fl-store-versionCode" class="form-control" id="fl-store-versionCode" pattern="^\d{1,4}$" data-error="The version code must be a number without any decimals and higher than all existing version codes" data-validation-version-code data-validation-version-code-error data-required-error="Please enter an app version code" data-validation-version-code-type data-validation-version-code-type-error="Please make sure the version code is higher than 1000" required />
+                    <input type="text" name="fl-store-versionCode" class="form-control" id="fl-store-versionCode" pattern="^\d+$" data-error="The version code must be a number without any decimals and higher than all existing version codes" data-validation-version-code data-validation-version-code-error data-required-error="Please enter an app version code" data-validation-version-code-type data-validation-version-code-type-error="Please make sure the version code is higher than 1000" required />
                     <div class="help-block with-errors"></div>
                     <p class="help-block"><small>The version code must be a number without any decimals and higher than all existing version codes.</small></p>
                   </div>

--- a/interface.html
+++ b/interface.html
@@ -102,7 +102,7 @@
                     <p class="help-block label-helper"><small>This is the version number of your app and will be displayed on the Google Play listing.</small></p>
                   </div>
                   <div class="col-sm-8">
-                    <input type="text" name="fl-store-versionNumber" class="form-control" id="fl-store-versionNumber" pattern="^.{1,}\..{1,}\..{1,}$" data-error="Please enter a version number in the required format" data-required-error="Please enter an app version number" data-validation-version-number-type data-validation-version-number-type-error data-validation-version-number data-validation-version-number-error="Please make sure the version number is higher than 1.0.0" maxlength="155" required />
+                    <input type="text" name="fl-store-versionNumber" class="form-control" id="fl-store-versionNumber" pattern="^\d+\.\d+\.\d+$" data-error="Please enter a version number in the required format" data-required-error="Please enter an app version number" data-validation-version-number-type data-validation-version-number-type-error data-validation-version-number data-validation-version-number-error="Please make sure the version number is higher than 1.0.0" maxlength="155" required />
                     <div class="help-block with-errors"></div>
                     <p class="help-block"><small>The required format for version number is <code>x.x.x</code>, where <code>x</code> is a number, e.g. <code>1.0.0</code>.</small></p>
                   </div>
@@ -338,7 +338,7 @@
                     <p class="help-block label-helper"><small>This is the version number of your app.</small></p>
                   </div>
                   <div class="col-sm-8">
-                    <input type="text" name="fl-ent-versionNumber" class="form-control" id="fl-ent-versionNumber" pattern="^.{1,}\..{1,}\..{1,}$" data-error="Please enter a version number in the required format" data-required-error="Please enter an app version number" data-validation-version-number-type data-validation-version-number-type-error data-validation-version-number data-validation-version-number-error="Please make sure the version number is higher than 1.0.0" maxlength="155" required />
+                    <input type="text" name="fl-ent-versionNumber" class="form-control" id="fl-ent-versionNumber" pattern="^\d+\.\d+\.\d+$" data-error="Please enter a version number in the required format" data-required-error="Please enter an app version number" data-validation-version-number-type data-validation-version-number-type-error data-validation-version-number data-validation-version-number-error="Please make sure the version number is higher than 1.0.0" maxlength="155" required />
                     <div class="help-block with-errors"></div>
                     <p class="help-block"><small>The required format for version number is <code>x.x.x</code>, where <code>x</code> is a number, e.g. <code>1.0.0</code>.</small></p>
                   </div>

--- a/js/interface.js
+++ b/js/interface.js
@@ -618,7 +618,7 @@ function saveAppStoreData(request) {
             helpLink: 'https://help.fliplet.com/app-settings/'
           }
         });
-  
+
         Fliplet.Studio.emit('track-event', {
           category: 'app_billing',
           action: 'open',
@@ -626,11 +626,11 @@ function saveAppStoreData(request) {
         });
 
         return;
-      } else {
-        return requestBuild('appStore', appStoreSubmission);
       }
+
+      return requestBuild('appStore', appStoreSubmission);
     }
-    
+
     return save('appStore', appStoreSubmission);
   });
 }
@@ -693,7 +693,7 @@ function saveEnterpriseData(request) {
             helpLink: 'https://help.fliplet.com/app-settings/'
           }
         });
-  
+
         Fliplet.Studio.emit('track-event', {
           category: 'app_billing',
           action: 'open',
@@ -701,9 +701,9 @@ function saveEnterpriseData(request) {
         });
 
         return;
-      } else {
-        return requestBuild('enterprise', enterpriseSubmission);
       }
+
+      return requestBuild('enterprise', enterpriseSubmission);
     }
 
     return save('enterprise', enterpriseSubmission);
@@ -1051,7 +1051,7 @@ $('form').validator({
     },
     'validation-version-code': function($el) {
       var newCode = $el.val();
-      var codeRegExp = /[^\d]/;
+      var codeRegExp = /^\d+$/;
 
       if (codeRegExp.test(newCode)) {
         $el.attr('data-validation-version-code-error', 'Please make sure the app version code is a number');
@@ -1064,11 +1064,14 @@ $('form').validator({
     'validation-version-code-type': function($el) {
       var oldVersionCode = $el.data('validation-version-code-type');
       var newVersionCode = $el.val();
-      var versionRegExp = /[^\d]/;
+      var versionRegExp = /^\d+$/;
 
       if (!oldVersionCode || !$el.val() || versionRegExp.test(newVersionCode)) {
         return false;
       }
+
+      oldVersionCode = parseInt(oldVersionCode, 10);
+      newVersionCode = parseInt(newVersionCode, 10);
 
       if (oldVersionCode < newVersionCode) {
         return false;
@@ -1173,7 +1176,7 @@ $('#appStoreConfiguration').validator().on('submit', function(event) {
   setTimeout(checkGroupErrors, 0);
 });
 
-$('#enterpriseConfiguration').validator().on('submit', function (event) {
+$('#enterpriseConfiguration').validator().on('submit', function(event) {
   if (!storeFeatures.private) {
     Fliplet.Studio.emit('overlay', {
       name: 'app-settings',

--- a/js/interface.js
+++ b/js/interface.js
@@ -1009,7 +1009,7 @@ $('form').validator({
     'validation-version-number': function($el) {
       var oldVersion = $el.data('validation-version-number');
       var newVersion = $el.val();
-      var versionRegExp = /^\d{1,}\.\d{1,}\.\d{1,}$/;
+      var versionRegExp = /^\d+\.\d+\.\d+$/;
 
       if (!oldVersion || !$el.val() || !versionRegExp.test(newVersion)) {
         return false;

--- a/js/interface.js
+++ b/js/interface.js
@@ -1039,9 +1039,9 @@ $('form').validator({
     },
     'validation-version-number-type': function($el) {
       var newVersion = $el.val();
-      var versionRegExp = /[^\d\.]/;
+      var versionRegExp = /^\d+\.\d+\.\d+$/;
 
-      if (versionRegExp.test(newVersion) && newVersion.length > 4) {
+      if (!versionRegExp.test(newVersion)) {
         $el.attr('data-validation-version-number-type-error', 'Please make sure the app version is a number');
 
         return true;


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-2119

Fixes the following problems:

1. Validation only allowed numbers between 0 and 9999
2. Validation doesn't correctly parse number strings to numbers before comparison, e.g. 9999 would be deemed larger than 10000
3. Version number allows non-numeric characters

Caused by https://github.com/Fliplet/fliplet-widget-google-submission/pull/61