### PR TITLE
XOR-962 [FIX] Show "Request pay" button as "Request app" after encountering the maximum limit

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -1346,6 +1346,7 @@ function publishApp(context) {
         break;
     }
   }).catch(function(err) {
+    $('.button-appStore-request, .button-enterprise-request').html('Request App <i class="fa fa-paper-plane"></i>');
     $('.button-appStore-request, .button-enterprise-request').prop('disabled', false);
 
     Fliplet.Modal.alert({ message: Fliplet.parseError(err) });


### PR DESCRIPTION
**Product areas affected**

Studio -> Publish -> Google Play Store publish

**What does this PR do?**

Implemented when user clicks on Request pay button to publish the native app after maximum limit, it should show as "Request app"

**JIRA ticket**

[click here](https://weboo.atlassian.net/browse/XOR-962)

**Result**

https://github.com/Fliplet/fliplet-widget-google-submission/assets/108272606/423b739f-5da4-4fc3-b00e-3c14f9e83302

**Checklist**

None

**Testing instructions**

None

**Deployment instructions**

None

**Author concerns**

None
