### PR TITLE
ID-2900 [Fix] Use result from the latest completed submission instead of the first

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -1489,7 +1489,7 @@ function submissionChecker(submissions) {
     return el.id;
   });
 
-  previousAppStoreSubmission = _.minBy(completedSubs, function(el) {
+  previousAppStoreSubmission = _.maxBy(completedSubs, function(el) {
     return el.id;
   });
 
@@ -1511,7 +1511,7 @@ function submissionChecker(submissions) {
     return el.id;
   });
 
-  previousEnterpriseSubmission = _.minBy(completedEnterpriseSubs, function(el) {
+  previousEnterpriseSubmission = _.maxBy(completedEnterpriseSubs, function(el) {
     return el.id;
   });
 


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-2900

Reverses what https://github.com/Fliplet/fliplet-widget-google-submission/pull/15 did, which picks the first successful app build instead of the latest.