### PR TITLE
Add support for hideStoreTab query parameter to hide Google Play tab

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -2,6 +2,10 @@ var widgetId = Fliplet.Widget.getDefaultId();
 var widgetData = Fliplet.Widget.getData(widgetId) || {};
 var storeFeatures = widgetData.appFeatures.hasOwnProperty('appStores')
   && widgetData.appFeatures.appStores.google;
+
+// Check for hideStoreTab query parameter
+var urlParams = new URLSearchParams(window.location.search);
+var hideStoreTab = urlParams.get('hideStoreTab') === 'true';
 var mustReviewTos = widgetData.mustReviewTos;
 var appName = '';
 var organizationName = '';
@@ -618,6 +622,14 @@ function init() {
       return app.id === Fliplet.Env.get('appId');
     });
   });
+
+  // Hide Google Play tab if hideStoreTab query parameter is true
+  if (hideStoreTab) {
+    $('#appstore-control').hide();
+    $('#appstore-tab').removeClass('active');
+    $('#fliplet-signed-control').addClass('active');
+    $('#fliplet-signed-tab').addClass('active');
+  }
 
   $('#fl-store-keywords').tokenfield();
 


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/DEV-848

## Summary

  - Add support for `hideStoreTab=true` query parameter to hide the Google Play tab when the widget is opened
  - When hidden, the Signed APK tab becomes the default active tab

## Test plan

  - Open the widget normally and verify all tabs are visible with Google Play tab active
  - Open the widget with ?hideStoreTab=true query parameter and verify:
    - Google Play tab is hidden
    - Signed APK tab is active and visible by default
    - Other tabs (Signed APK, Push Notifications) remain accessible